### PR TITLE
Replace deprecated gulp-util

### DIFF
--- a/index.js
+++ b/index.js
@@ -11,7 +11,8 @@
  * Module dependencies.
  */
 var through = require('through2');
-var gutil = require('gulp-util');
+var PluginError = require('plugin-error');
+var replaceExtension = require('replace-ext');
 var gulpRemarkable = require('./lib/gulp-remarkable');
 
 module.exports = function remarkable(options) {
@@ -21,7 +22,7 @@ module.exports = function remarkable(options) {
     }
 
     if (file.isStream()) {
-      callback(new gutil.PluginError('gulp-remarkable', 'Streaming not supported'));
+      callback(new PluginError('gulp-remarkable', 'Streaming not supported'));
       return;
     }
     
@@ -30,10 +31,10 @@ module.exports = function remarkable(options) {
 
       file.contents = new Buffer(md.render(file.contents.toString()));
       
-      file.path = gutil.replaceExtension(file.path, '.html');
+      file.path = replaceExtension(file.path, '.html');
       this.push(file);
     } catch (err) {
-      this.emit('error', new gutil.PluginError('gulp-remarkable', err, {fileName: file.path}));
+      this.emit('error', new PluginError('gulp-remarkable', err, {fileName: file.path}));
     }
 
     callback();

--- a/package.json
+++ b/package.json
@@ -30,21 +30,23 @@
     "md"
   ],
   "dependencies": {
-    "gulp-util": ">=3.0.1",
     "highlight.js": ">=8.3.0",
+    "plugin-error": "1.0.1",
     "remarkable": "^1.4.1",
+    "replace-ext": "1.0.0",
     "through2": ">=0.6.3"
   },
   "devDependencies": {
     "coveralls": "*",
-    "istanbul": "*",
-    "jshint": "*",
-    "mocha": ">=2",
-    "mocha-lcov-reporter": "*",
     "gulp": ">=3.8.10",
     "gulp-jshint": ">=1.9.0",
+    "gulp-spawn-mocha": ">=0.5.1",
+    "istanbul": "*",
+    "jshint": "*",
     "jshint-stylish": ">=1.0.0",
-    "gulp-spawn-mocha": ">=0.5.1"
+    "mocha": ">=2",
+    "mocha-lcov-reporter": "*",
+    "vinyl": "2.1.0"
   },
   "licenses": [
     {

--- a/test/test.js
+++ b/test/test.js
@@ -11,7 +11,7 @@
  * Module dependencies.
  */
 var assert = require('assert');
-var gutil = require('gulp-util');
+var Vinyl = require('vinyl');
 var remarkableStream = require('../index');
 
 describe('gulp-remarkable should convert md to html', function() {
@@ -26,7 +26,7 @@ describe('gulp-remarkable should convert md to html', function() {
     });
     mdStream.on('end', done);
 
-    mdStream.write(new gutil.File({
+    mdStream.write(new Vinyl({
       path: 'default.md',
       contents: new Buffer(actual)
     }));
@@ -52,7 +52,7 @@ describe('gulp-remarkable should convert md to html', function() {
     });
     mdStream.on('end', done);
 
-    mdStream.write(new gutil.File({
+    mdStream.write(new Vinyl({
       path: 'typographer.md',
       contents: new Buffer(actual)
     }));
@@ -76,7 +76,7 @@ describe('gulp-remarkable should convert md to html', function() {
     });
     mdStream.on('end', done);
 
-    mdStream.write(new gutil.File({
+    mdStream.write(new Vinyl({
       path: 'typographer.md',
       contents: new Buffer(actual)
     }));


### PR DESCRIPTION
[`gulp-util`](https://www.npmjs.com/package/gulp-util) has been deprecated recently. Continuing to use this dependency may prevent the use of your library with the recently released version 4 of Gulp, it is important to replace `gulp-util`.

See:
- https://medium.com/gulpjs/gulp-util-ca3b1f9f9ac5
- https://github.com/gulpjs/gulp-util/issues/143